### PR TITLE
Test action-ansiblelint

### DIFF
--- a/.github/workflows/ansiblelint.yaml
+++ b/.github/workflows/ansiblelint.yaml
@@ -13,7 +13,7 @@ jobs:
           python-version: "3.11"
 
       - name: ansible-lint github-pr-check
-        uses: reviewdog/action-ansiblelint@master
+        uses: umatare5/action-ansiblelint@244a5ac59a9e881e206ef575841fd1427a3ee0e7
         with:
           github_token: ${{ secrets.github_token }}
           reporter: github-pr-check
@@ -21,7 +21,7 @@ jobs:
           ansiblelint_version: 24.12.2
 
       - name: ansible-lint github-check
-        uses: reviewdog/action-ansiblelint@master
+        uses: umatare5/action-ansiblelint@244a5ac59a9e881e206ef575841fd1427a3ee0e7
         with:
           github_token: ${{ secrets.github_token }}
           reporter: github-check
@@ -30,7 +30,7 @@ jobs:
           ansiblelint_version: 24.12.2
 
       - name: ansible-lint github-pr-review
-        uses: reviewdog/action-ansiblelint@master
+        uses: umatare5/action-ansiblelint@244a5ac59a9e881e206ef575841fd1427a3ee0e7
         with:
           github_token: ${{ secrets.github_token }}
           reporter: github-pr-review

--- a/.github/workflows/ansiblelint.yaml
+++ b/.github/workflows/ansiblelint.yaml
@@ -18,6 +18,7 @@ jobs:
           github_token: ${{ secrets.github_token }}
           reporter: github-pr-check
           ansiblelint_flags: "ansiblelint-testdata/test.yml"
+          ansiblelint_version: 24.12.2
 
       - name: ansible-lint github-check
         uses: reviewdog/action-ansiblelint@master
@@ -26,6 +27,7 @@ jobs:
           reporter: github-check
           level: warning
           ansiblelint_flags: "ansiblelint-testdata/test.yml"
+          ansiblelint_version: 24.12.2
 
       - name: ansible-lint github-pr-review
         uses: reviewdog/action-ansiblelint@master
@@ -33,3 +35,4 @@ jobs:
           github_token: ${{ secrets.github_token }}
           reporter: github-pr-review
           ansiblelint_flags: "ansiblelint-testdata/test.yml"
+          ansiblelint_version: 24.12.2

--- a/.github/workflows/ansiblelint.yaml
+++ b/.github/workflows/ansiblelint.yaml
@@ -1,0 +1,35 @@
+name: reviewdog
+on:
+  pull_request:
+jobs:
+  ansible-lint:
+    name: runner / ansible-lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: ansible-lint github-pr-check
+        uses: reviewdog/action-ansiblelint@master
+        with:
+          github_token: ${{ secrets.github_token }}
+          reporter: github-pr-check
+          ansiblelint_flags: "ansiblelint-testdata/test.yml"
+
+      - name: ansible-lint github-check
+        uses: reviewdog/action-ansiblelint@master
+        with:
+          github_token: ${{ secrets.github_token }}
+          reporter: github-check
+          level: warning
+          ansiblelint_flags: "ansiblelint-testdata/test.yml"
+
+      - name: ansible-lint github-pr-review
+        uses: reviewdog/action-ansiblelint@master
+        with:
+          github_token: ${{ secrets.github_token }}
+          reporter: github-pr-review
+          ansiblelint_flags: "ansiblelint-testdata/test.yml"

--- a/ansiblelint-testdata/test.yml
+++ b/ansiblelint-testdata/test.yml
@@ -1,0 +1,10 @@
+---
+- name: Test Ansible PlayBook
+  hosts: all
+
+  tasks:
+    - name: Test Command
+      command: ls -la
+    - name: Test Shell
+      shell: ls
+


### PR DESCRIPTION
This PR is testing the change in https://github.com/reviewdog/action-ansiblelint/pull/47.

- In 2nd commit [ansiblelint: Run reviewdog/action-ansiblelint](https://github.com/umatare5/actions-sandbox/pull/1/commits/84785d75d818a6d8ea06e771efacc6c91ff51984):
  
  I confirm that the old version of `ansible-lint` works fine.
  ![Screenshot 2024-12-24 at 0 27 27](https://github.com/user-attachments/assets/308c0f36-57b1-4e48-b698-6136fb6b049b)

- In 3rd commit [ansiblelint: Use latest ansible-lint v24.12.2](https://github.com/umatare5/actions-sandbox/pull/1/commits/db50a5912c8551d094b1896b1639a35196ff2ea3):

  I confirmed that the latest `ansible-lint` doesn't work because `Unable to parse ansible cli version: ansible 2.10.17`.
  ![Screenshot 2024-12-24 at 0 25 42](https://github.com/user-attachments/assets/a6fc304a-931a-45d4-b149-3d416e10c1bd)

- In 4th commit [ansiblelint: Install ansible as a dependency of ansible-lint](https://github.com/umatare5/actions-sandbox/pull/1/commits/4ad3269f3b00e6695da04307aa4f8cfb1979e026):

  I confirmed that the latest `ansible-lint` works fine using the changes in PR #47.
  ![Screenshot 2024-12-24 at 0 28 31](https://github.com/user-attachments/assets/ac4250d3-6db7-4e2e-ba5e-8e65384695e4)
